### PR TITLE
Config abstractions and combination simulation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+disable=cyclic-import

--- a/finance_macros/simulation/building_society_savings_contract.py
+++ b/finance_macros/simulation/building_society_savings_contract.py
@@ -1,6 +1,6 @@
 """Building society savings contract simulation."""
 from datetime import date
-from typing import Optional
+from typing import Optional, List
 
 from finance_macros.simulation.core import TimeSeriesSimulation, SimulationContext
 from finance_macros.simulation.investment import InvestmentSimulation
@@ -80,3 +80,7 @@ class BuildingSocietySavingsContract(TimeSeriesSimulation):
                 results[key] += [0] * len(mortgage_results["date"])
 
         return results
+
+    def get_column_names(self) -> List[str]:
+        return ["date", "capital", "interest", "mortgage_interest", "mortgage_pay_rate",
+                "mortgage_capital", "mortgage_capital_pay_rate"]

--- a/finance_macros/simulation/combination.py
+++ b/finance_macros/simulation/combination.py
@@ -1,0 +1,203 @@
+"""Simulation combining multiple different ones."""
+import re
+from enum import Enum
+from typing import List, Dict, Any
+
+from finance_macros.simulation.config import Promptable, CLIArgument, Parsable
+from finance_macros.simulation.core import Simulation, SimulationContext
+from finance_macros.simulation.overlay import Overlay
+
+
+class CombinationOperation(Enum):
+    """An operation to apply to the results of the simulations."""
+    ADD = 1
+    SUBTRACT = 2
+    MULTIPLY = 3
+    DIVIDE = 4
+    MODULO = 5
+    INT_DIVIDE = 6
+
+    @staticmethod
+    # pylint: disable=unused-argument
+    def choices_provider(context: SimulationContext) -> List[str]:
+        """Returns the choices for the CLI."""
+        return [operation.name for operation in CombinationOperation]
+
+    def __str__(self):
+        match self:
+            case CombinationOperation.ADD:
+                return "+"
+            case CombinationOperation.SUBTRACT:
+                return "-"
+            case CombinationOperation.MULTIPLY:
+                return "*"
+            case CombinationOperation.DIVIDE:
+                return "/"
+            case CombinationOperation.MODULO:
+                return "%"
+            case CombinationOperation.INT_DIVIDE:
+                return "//"
+            case other:
+                raise ValueError(f"Invalid operation: {other}")
+
+
+# pylint: disable=too-few-public-methods
+class CombinationOperationParser(Parsable):
+    """Parser for `CombinationOperation`"""
+
+    @staticmethod
+    def get_value(context: SimulationContext, input_str: str) -> "CombinationOperation":
+        match input_str.lower():
+            case "add" | "+" | "plus":
+                return CombinationOperation.ADD
+            case "subtract" | "-" | "minus":
+                return CombinationOperation.SUBTRACT
+            case "multiply" | "*" | "times":
+                return CombinationOperation.MULTIPLY
+            case "divide" | "/" | "divided by":
+                return CombinationOperation.DIVIDE
+            case "modulo" | "%" | "mod":
+                return CombinationOperation.MODULO
+            case "int_divide" | "//" | "int_divided by":
+                return CombinationOperation.INT_DIVIDE
+            case other:
+                raise ValueError(f"Invalid operation: {other}")
+
+
+class Combination(Simulation):
+    """A special simulation that combines the results of one or multiple simulations, not by
+    overlaying, but applying functions to the simulation's columns, including calculating new
+    columns based on different simulations."""
+
+    class CombinationFunction(Parsable):
+        """A function applying to one or more simulations' columns. Simulations specify which
+        simulations' columns to use, and the operation specifies how to combine them. A simulation
+        can be included multiple times, and the operation can be applied to multiple columns of that
+        same simulation. In any case, the length of the simulations and columns lists must be the
+        same."""
+        operation: CombinationOperation
+        simulations: List[Simulation]
+        columns: List[str]
+
+        def __init__(self, key: str, operation: CombinationOperation, simulations: List[Simulation],
+                     columns: List[str]):
+            self.key = key
+            self.operation = operation
+            self.simulations = simulations
+            self.columns = columns
+            assert len(self.simulations) == len(
+                self.columns), "Length of simulations and columns must be the same"
+
+        @staticmethod
+        def get_value(context: SimulationContext,
+                      input_str: str) -> "Combination.CombinationFunction":
+            pattern = r"(?P<sim1>[\w\d]+)\.(?P<key1>[\w\d]+) ?(?P<operation>.{1,4}?) ?\
+(?P<sim2>[\w\d]+)\.(?P<key2>[\w\d]+)"
+            match = re.match(pattern, input_str)
+            if match:
+                sim1 = match.group("sim1")
+                key1 = match.group("key1")
+                operation = match.group("operation")
+                sim2 = match.group("sim2")
+                key2 = match.group("key2")
+                sims = context.get_simulations_with_ids(sim1, sim2)
+                operation = CombinationOperationParser.get_value(context, operation)
+                return Combination.CombinationFunction(
+                    key1 + str(operation) + key2,
+                    operation,
+                    sims,
+                    [key1, key2]
+                )
+            raise ValueError(f"Can't interpret '{input_str}' as a combination function.")
+
+        def evaluate(self, results: Dict) -> Dict:
+            """Evaluate the function on the results."""
+            data = results.copy()
+            data[self.key] = data[
+                self.simulations[0].get_short_identifier() + "_" + self.columns[0]].copy()
+            if len(self.simulations) == 1:
+                return data
+            for i in range(1, len(self.simulations)):
+                simulation = self.simulations[i]
+                short_id = simulation.get_short_identifier()
+                column = short_id + "_" + self.columns[i]
+                for j in range(len(data[self.key])):
+                    match self.operation:
+                        case CombinationOperation.ADD:
+                            data[self.key][j] += \
+                                data[column][j]
+                        case CombinationOperation.SUBTRACT:
+                            data[self.key][j] -= \
+                                data[column][j]
+                        case CombinationOperation.MULTIPLY:
+                            data[self.key][j] *= \
+                                data[column][j]
+                        case CombinationOperation.DIVIDE:
+                            data[self.key][j] /= \
+                                data[column][j]
+                        case CombinationOperation.MODULO:
+                            data[self.key][j] %= \
+                                data[column][j]
+                        case CombinationOperation.INT_DIVIDE:
+                            data[self.key][j] //= \
+                                data[column][j]
+                        case other:
+                            raise ValueError(f"Invalid operation {other}.")
+            return data
+
+    functions: List[CombinationFunction]
+    overlay: Overlay
+
+    def __init__(self, export_directory: str, identifier: str, context: SimulationContext,
+                 functions: List[CombinationFunction]):
+        super().__init__(export_directory, identifier, context)
+        self.functions = functions
+        simulationslist = [function.simulations for function in self.functions]
+        sims = [sim.get_short_identifier() for sublist in simulationslist for sim in sublist]
+        self.overlay = Overlay(export_directory, identifier, context, sims)
+
+    def simulate(self):
+        self.overlay.simulate()
+
+    def get_results(self) -> Dict:
+        results = self.overlay.get_results()
+        for function in self.functions:
+            results = function.evaluate(results)
+        return results
+
+    def get_column_names(self) -> List[str]:
+        return [function.key for function in self.functions] + self.overlay.get_column_names()
+
+
+class CombinationFunctionList(Promptable):
+    """A list of combination functions used for CLI configuration."""
+    functions: List[Combination.CombinationFunction]
+
+    def __init__(self):
+        args = [
+            CLIArgument("function_count", int, display_name="Number of functions",
+                        additional_arg_provider=self.additional_arg_provider),
+        ]
+        super().__init__(args)
+        self.functions = []
+
+    @staticmethod
+    def additional_arg_provider(context: SimulationContext, value) -> List[CLIArgument]:
+        """The additional arg provider callback for the function count argument."""
+        column_specifications = []
+        for simulation in context.simulations:
+            for column in simulation.get_column_names():
+                column_specifications.append(simulation.get_short_identifier() + "." + column)
+        args: List[CLIArgument] = [
+            CLIArgument("function_specification_" + str(i + 1), Combination.CombinationFunction,
+                        choices_provider=lambda _: column_specifications)
+            for i in range(value)
+        ]
+        return args
+
+    def process_values(self, context: SimulationContext, values: Dict[str, Any]) -> List[
+        Combination.CombinationFunction]:
+        self.functions = []
+        for i in range(values["function_count"]):
+            self.functions.append(values["function_specification_" + str(i + 1)])
+        return self.functions

--- a/finance_macros/simulation/investment.py
+++ b/finance_macros/simulation/investment.py
@@ -57,3 +57,6 @@ class InvestmentSimulation(TimeSeriesSimulation):
             lambda _: self.invest_one_month(),
             1
         )
+
+    def get_column_names(self) -> List[str]:
+        return ["capital", "profit", "paid_in", "date"]

--- a/finance_macros/simulation/main.py
+++ b/finance_macros/simulation/main.py
@@ -20,11 +20,9 @@ def run_simulation(context: SimulationContext, simulation_type: str, export_dire
     :param export_directory: The directory to export the simulation to
     """
     config = CONFIG.get_simulation_type(simulation_type)
-    args = {}
     count = CSV_FILE_COUNT_PER_SIM_TYPE[simulation_type]
     print(f"\n{config.display_name} simulation {count}:")
-    for arg in config.arguments:
-        args[arg.key] = arg.load_value(context)
+    args = config.prompt(context)
     identifier = f"{simulation_type}_{count}"
     sim: Simulation = config.type(identifier=identifier, export_directory=export_directory,
                                   context=context,

--- a/finance_macros/simulation/mortgage.py
+++ b/finance_macros/simulation/mortgage.py
@@ -10,6 +10,7 @@ class MortgageSimulation(TimeSeriesSimulation):
     """A simulation of a mortgage with a fixed borrowed amount, down payment, interest rate and
     monthly payment. The monthly payment is constant, but the principal and interest paid
     changes according to the remaining due amount (and interest of course)."""
+    mortgage_sum: float
     borrowed_amount: float
     downpayment: float
     yearly_interest: float
@@ -21,6 +22,7 @@ class MortgageSimulation(TimeSeriesSimulation):
     _paid_cost: List[float]
     _principal_rate: List[float]
     _interest_rate: List[float]
+    _net_worth: List[float]
     pay_off_date: Optional[date]
 
     # pylint: disable=too-many-arguments
@@ -29,6 +31,7 @@ class MortgageSimulation(TimeSeriesSimulation):
                  mortgage_sum: float,
                  downpayment_ratio: float, interest_rate: float, monthly_payment: float):
         super().__init__(export_directory, identifier, context, start_date, end_date)
+        self.mortgage_sum = mortgage_sum
         self.borrowed_amount = mortgage_sum * (1 - downpayment_ratio)
         self.downpayment = mortgage_sum * downpayment_ratio
         self.yearly_interest = interest_rate
@@ -40,6 +43,7 @@ class MortgageSimulation(TimeSeriesSimulation):
         self._paid_cost = [self.downpayment]
         self._principal_rate = [0]
         self._interest_rate = [0]
+        self._net_worth = [self.mortgage_sum - self._due_amount[-1]]
 
     def calculate_monthly_interest(self) -> float:
         """Calculate the monthly interest rate from the yearly interest rate."""
@@ -55,6 +59,7 @@ class MortgageSimulation(TimeSeriesSimulation):
         self._paid_cost.append(self._paid_cost[-1] + self.monthly_payment)
         self._principal_rate.append(principal_paid)
         self._interest_rate.append(new_interest_paid)
+        self._net_worth.append(self.mortgage_sum - self._due_amount[-1])
 
     def get_results(self):
         return {
@@ -64,6 +69,7 @@ class MortgageSimulation(TimeSeriesSimulation):
             "paid_cost": self._paid_cost,
             "principal_rate": self._principal_rate,
             "interest_rate": self._interest_rate,
+            "net_worth": self._net_worth,
             "date": self._dates
         }
 
@@ -78,3 +84,15 @@ class MortgageSimulation(TimeSeriesSimulation):
         except StopIteration:
             self.pay_off_date = None
         print("Pay off date: ", self.pay_off_date)
+
+    def get_column_names(self) -> List[str]:
+        return [
+            "principal_paid",
+            "interest_paid",
+            "due_amount",
+            "paid_cost",
+            "principal_rate",
+            "interest_rate",
+            "net_worth",
+            "date"
+        ]

--- a/finance_macros/simulation/overlay.py
+++ b/finance_macros/simulation/overlay.py
@@ -1,0 +1,45 @@
+"""Overlay simulation"""
+from typing import List, Dict
+
+import pandas as pd
+
+from finance_macros.data_visualization import interpolate_data_nonlinear
+from finance_macros.simulation.core import Simulation, SimulationContext
+
+
+class Overlay(Simulation):
+    """A special simulation that combines the results of multiple simulations."""
+    simulations: List[Simulation]
+
+    def __init__(self, export_directory: str, identifier: str, context: SimulationContext,
+                 simulations: List[str]):
+        super().__init__(export_directory, identifier, context)
+        self.simulations = context.get_simulations_with_ids(*simulations)
+
+    def simulate(self):
+        for simulation in self.simulations:
+            simulation.simulate()
+
+    def get_results(self) -> Dict:
+        tmp = {}
+        for simulation in self.simulations:
+            tmp[simulation.get_short_identifier()] = simulation.get_results()
+        results = {}
+        start_date = min(
+            map(lambda sim: sim["date"][0], tmp.values()))
+        end_date = max(
+            map(lambda sim: sim["date"][-1], tmp.values()))
+        for i, (sim, result) in enumerate(tmp.items()):
+            interpolated = interpolate_data_nonlinear(pd.DataFrame(result), "date", start_date,
+                                                      end_date)
+            for key, values in interpolated.items():
+                if key != "date":
+                    results[sim + "_" + key] = list(values)
+
+            if i == 0:
+                results["date"] = list(interpolated["date"])
+        return results
+
+    def get_column_names(self) -> List[str]:
+        nameslist = [sim.get_column_names() for sim in self.simulations]
+        return [col for sublist in nameslist for col in sublist]


### PR DESCRIPTION
- move overlay simulation to own file
- add combination simulation that does basic arithmetic on columns of multiple simulations
- add net worth column to mortgage
- add Parsable abstract class to generalize parsable complex objects (from one input string)
- add Promptable config object as an abstract class to enable more custom cli-interactions (e.g. dependent arguments)